### PR TITLE
Factor out replicated can_reference concept to common.hpp

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -18,12 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: 
+        config:
         - {
             name: "Windows 2022 MSVC",
             os: windows-2022,
             build_type: "Release", cxx: "cl",
-          }  
+          }
         - {
             name: "Ubuntu 20.04 GCC 10.2",
             os: ubuntu-20.04,
@@ -43,8 +43,8 @@ jobs:
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{github.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source 
-      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # Note the current convention is to use the -S and -B options here to specify source
+      # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DRANGES_BUILD_TESTS=On -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}}
 
@@ -57,6 +57,6 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       shell: bash
-      # Execute tests defined by the CMake configuration.  
+      # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C $BUILD_TYPE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if (RANGES_BUILD_TESTS)
     set(test "${PROJECT_NAME}-test-${name}")
     add_executable(${test}
       "${source}"
-      $<TARGET_OBJECTS:${PROJECT_NAME}-catch-main>)
+      $<TARGET_OBJECTS:${PROJECT_NAME}-catch-main> "include/tl/tl.h")
     if(MSVC)
         set_target_properties(${test} PROPERTIES CXX_STANDARD 23)
     else()

--- a/include/tl/adjacent_transform.hpp
+++ b/include/tl/adjacent_transform.hpp
@@ -10,10 +10,6 @@
 
 namespace tl {
    namespace detail {
-      template<class T> using with_reference = T&;
-      template<class T> concept can_reference
-         = requires { typename with_reference<T>; };
-
       template<class F, class... Ts> struct regular_invocable_impl {
          static constexpr bool value = std::regular_invocable<F, Ts...>;
       };
@@ -58,7 +54,7 @@ namespace tl {
       public:
          using value_type =
             std::remove_cvref_t<
-               typename meta::repeat_into<std::ranges::range_reference_t<Base>, N, 
+               typename meta::repeat_into<std::ranges::range_reference_t<Base>, N,
                                     meta::partial<std::invoke_result, maybe_const<Const, F>&>::template apply
                >::type::type>;
 
@@ -122,7 +118,7 @@ namespace tl {
          }
 
          constexpr auto begin() const
-            requires std::ranges::range<const InnerView>&& const_invocable           
+            requires std::ranges::range<const InnerView>&& const_invocable
          {
             return basic_iterator{ cursor<true>(*this, inner_.begin()) };
          }
@@ -181,7 +177,7 @@ namespace tl {
          };
       }  // namespace detail
 
- 
+
       template <std::size_t N>
       inline constexpr auto adjacent_transform = detail::adjacent_transform_fn<N>{};
       inline constexpr auto pairwise_transform = detail::adjacent_transform_fn<2>{};

--- a/include/tl/common.hpp
+++ b/include/tl/common.hpp
@@ -22,6 +22,10 @@ namespace tl {
          else
             return std::output_iterator_tag{};
       }
+
+      template<class T> using with_reference = T&;
+      template<class T> concept can_reference
+         = requires { typename with_reference<T>; };
    }
 
    template <class... V>

--- a/include/tl/tl.h
+++ b/include/tl/tl.h
@@ -1,0 +1,25 @@
+#ifndef TL_RANGES_TL_HPP
+#define TL_RANGES_TL_HPP
+
+#include "adjacent.hpp"
+#include "adjacent_transform.hpp"
+#include "cartesian_product.hpp"
+#include "chunk.hpp"
+#include "chunk_by.hpp"
+#include "chunk_by_key.hpp"
+#include "cycle.hpp"
+#include "enumerate.hpp"
+#include "generate.hpp"
+#include "generate_n.hpp"
+#include "partial_sum.hpp"
+#include "repeat.hpp"
+#include "repeat_n.hpp"
+#include "stride.hpp"
+#include "to.hpp"
+#include "transform_join.hpp"
+#include "transform_maybe.hpp"
+#include "repeat_n.hpp"
+#include "zip.hpp"
+#include "zip_transform.hpp"
+
+#endif

--- a/include/tl/zip_transform.hpp
+++ b/include/tl/zip_transform.hpp
@@ -8,12 +8,6 @@
 #include "common.hpp"
 
 namespace tl {
-   namespace detail {
-      template<class T> using with_reference = T&;
-      template<class T> concept can_reference
-         = requires { typename with_reference<T>; };
-   }
-
    template<std::copy_constructible F, std::ranges::input_range... Views>
    requires (std::ranges::view<Views> && ...) && (sizeof...(Views) > 0) && std::is_object_v<F>&&
       std::regular_invocable<F&, std::ranges::range_reference_t<Views>...>&&
@@ -47,8 +41,8 @@ namespace tl {
          ziperator<Const> inner_ = ziperator<Const>();
 
       public:
-         using value_type = 
-            std::remove_cvref_t<std::invoke_result_t<maybe_const<Const, F>&, 
+         using value_type =
+            std::remove_cvref_t<std::invoke_result_t<maybe_const<Const, F>&,
                                 std::ranges::range_reference_t<maybe_const<Const, Views>>...>>;
 
          constexpr cursor(Parent& parent, ziperator<Const> inner) :


### PR DESCRIPTION
The can_reference concept was defined in both adjacent_transform and zip_transform.h.
This factors this concept out and puts it in common.hpp

Also added tl.h to include everything to check for similar, hopefully one day this will be a single module!